### PR TITLE
feat: Introduce generic type for sync method in vtiger-client

### DIFF
--- a/src/lib/vtiger-client.ts
+++ b/src/lib/vtiger-client.ts
@@ -419,22 +419,22 @@ export class VTigerClient extends VtigerClientHelper {
    *   lastModifiedTime: timestamp
    *  }}
    */
-  public sync = async (
+  public sync = async <MODULE = any> (
     modifiedTime: number,
     elementType: StandardListType,
     syncType: 'user' | 'userandgroup' | 'application' = 'application',
   ): Promise<
     VtigerApiResult<{
-      updated: Partial<StandardListType[]>;
-      deleted: Partial<StandardListType[]>;
+      updated: Partial<MODULE []>;
+      deleted: string [];
       more: boolean;
       lastModifiedTime: number;
     }>
   > => {
     return new Promise<
       VtigerApiResult<{
-        updated: Partial<StandardListType[]>;
-        deleted: Partial<StandardListType[]>;
+        updated: Partial<MODULE []>;
+        deleted: string [];
         more: boolean;
         lastModifiedTime: number;
       }>
@@ -442,8 +442,8 @@ export class VTigerClient extends VtigerClientHelper {
       this.httpClient
         .get<
           VtigerApiResponse<{
-            updated: Partial<StandardListType[]>;
-            deleted: Partial<StandardListType[]>;
+            updated: Partial<MODULE []>;
+            deleted: string [];
             more: boolean;
             lastModifiedTime: number;
           }>


### PR DESCRIPTION
Refactor the sync method to use a generic type parameter, enabling greater flexibility when handling updated elements. The deleted elements array has been changed to a string array, simplifying the representation of deletions across different module types.